### PR TITLE
Increasing the log container timeout to 10 minutes

### DIFF
--- a/logservice.go
+++ b/logservice.go
@@ -23,7 +23,7 @@ var (
 const (
 	region         = "us-west-2"
 	bucket         = "logs.screwdriver.cd"
-	startupTimeout = time.Minute
+	startupTimeout = 10 * time.Minute
 )
 
 func main() {


### PR DESCRIPTION
- We were hitting slowness downloading build containers from docker hub
- This should change into something more reliable over time, such as a
  separate process that monitors build pods and cleans them up
