### PR TITLE
Added retries to the uploader, cleaned up a little

### DIFF
--- a/logfilesaver.go
+++ b/logfilesaver.go
@@ -76,5 +76,18 @@ func (l *logFile) Write(p []byte) (int, error) {
 func (l *logFile) Close() error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	return l.file.Close()
+
+	// If the file is already closed, make this a no-op
+	if l.file == nil {
+		return nil
+	}
+
+	f := l.file
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	l.file = nil
+
+	return os.Remove(f.Name())
 }


### PR DESCRIPTION
- Any error or non-200 response will be retried 6 times
- If the current try number is N, there is a delay of N \* N seconds
  before the next attempt.
- Temporary log files are cleaned up when the file is closed
- Logfiles are saved asynchronously except for the final StepSaver.Close() call
- If step saving is constantly failing, steps will be marked complete in
  the API, but logs wouldn't make it to the Store
- If step saving succeeds intermittently, log files will be shipped to
  the Store out of order
- Also made the linesPerFile flag actually work
