### PR TITLE
fix: switch from bufio.Scanner to bufio.Reader for reading log

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ workflow:
     - deploy
 
 shared:
-    image: golang
+    image: golang:1.8.3
     environment:
         GOPATH: /sd/workspace
 


### PR DESCRIPTION
Currently, if the log is too long for one line, build will crash/stuck.

We switch from  `bufio.Scanner` to `bufio.Reader` in launcher already.
https://github.com/screwdriver-cd/launcher/pull/119

Now the super long line will be passed to log-service, so the log-service also need to switch from  `bufio.Scanner` to `bufio.Reader` to parse the line.

Related to https://github.com/screwdriver-cd/screwdriver/issues/525
