### PR TITLE
fix: force blocking IO on emitter to properly handle EOF on darwin

### DIFF
--- a/logservice.go
+++ b/logservice.go
@@ -120,6 +120,10 @@ func (a app) LogReader() io.Reader {
 		os.Exit(0)
 	}
 
+	// Force blocking IO. This is necessary for readln() to exit on EOF with go 1.9 and
+	// above on darwin. See https://github.com/golang/go/issues/24164 for details
+	source.Fd()
+
 	return source
 }
 


### PR DESCRIPTION
With Go 1.9 and above on darwin, log-service won't terminate on its own after emitter receiving EOF from launcher. Details can be found at https://github.com/golang/go/issues/24164.

This PR implements the workaround suggested in the issue.