### PR TITLE
fix: bump lines per file to 1000

### DIFF
--- a/logservice.go
+++ b/logservice.go
@@ -20,7 +20,7 @@ var (
 )
 
 const (
-	defaultLinesPerFile = 100
+	defaultLinesPerFile = 1000
 	startupTimeout      = 10 * time.Minute
 	logBufferSize       = 200
 	maxLineSize         = 1000

--- a/logservice_test.go
+++ b/logservice_test.go
@@ -25,7 +25,7 @@ const (
 	mockEmitterPath  = "./data/emitterdata"
 	mockToken        = "FAKETOKEN"
 	mockBuildID      = "fakebuildid"
-	mockLinesPerFile = 100
+	mockLinesPerFile = 1000
 )
 
 func mockEmitter() *os.File {


### PR DESCRIPTION
bump lines per file to 1000 so that we will have less files and less call to fetch logs

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1043