### PR TITLE
feat(1114): add additional flag for apiUrl [2]

### DIFF
--- a/logservice.go
+++ b/logservice.go
@@ -34,7 +34,8 @@ func main() {
 // parseFlags returns an App object from CLI flags.
 func parseFlags() app {
 	a := app{}
-	flag.StringVar(&a.url, "api-uri", "", "Base URI for the Screwdriver Store API ($SD_API_URI)")
+	flag.StringVar(&a.apiUrl, "api-uri", "", "Base URI for the Screwdriver API ($SD_API_URL)")
+	flag.StringVar(&a.storeUrl, "store-uri", "", "Base URI for the Screwdriver Store API ($SD_STORE_URL)")
 	flag.StringVar(&a.emitterPath, "emitter", "/var/run/sd/emitter", "Path to the log emitter file")
 	flag.StringVar(&a.buildID, "build", "", "ID of the build that is emitting logs ($SD_BUILDID)")
 	flag.StringVar(&a.token, "token", "", "JWT for authenticating with the Store API ($SD_TOKEN)")
@@ -69,12 +70,16 @@ func parseFlags() app {
 		os.Exit(0)
 	}
 
-	if len(a.url) == 0 {
-		a.url = os.Getenv("SD_API_URI")
+	if len(a.storeUrl) == 0 {
+		a.storeUrl = os.Getenv("SD_STORE_URL")
 	}
 
-	if len(a.url) == 0 {
-		log.Println("No API URI specified. Cannot send logs anywhere.")
+	if len(a.apiUrl) == 0 {
+		a.apiUrl = os.Getenv("SD_API_URL")
+	}
+
+	if len(a.storeUrl) == 0 {
+		log.Println("No STORE API URI specified. Cannot send logs anywhere.")
 		flag.Usage()
 		os.Exit(0)
 	}
@@ -94,13 +99,14 @@ type app struct {
 	token,
 	emitterPath,
 	buildID,
-	url string
+	apiUrl,
+	storeUrl string
 	linesPerFile int
 }
 
 // Uploader returns an Uploader object for the Screwdriver Store
 func (a app) Uploader() sdstoreuploader.SDStoreUploader {
-	return sdstoreuploader.NewFileUploader(a.buildID, a.url, a.token)
+	return sdstoreuploader.NewFileUploader(a.buildID, a.storeUrl, a.token)
 }
 
 // LogReader returns a Reader that is the log source.

--- a/logservice_test.go
+++ b/logservice_test.go
@@ -21,7 +21,8 @@ type logMap map[string][]*logLine
 
 const (
 	defaultEmitter   = "/var/run/sd/emitter"
-	mockURL          = "http://fakeurl"
+	mockStoreURL     = "http://fakeurl"
+	mockAPIURL     = "http://fakeAPIurl"
 	mockEmitterPath  = "./data/emitterdata"
 	mockToken        = "FAKETOKEN"
 	mockBuildID      = "fakebuildid"
@@ -77,7 +78,8 @@ func newRealApp() App {
 
 func newAppFromEmitter(emitterPath string) App {
 	a := app{
-		url:         "http://localhost:8080",
+		storeUrl:         "http://localhost:80",
+		apiUrl:         "http://localhost:8080",
 		emitterPath: emitterPath,
 		buildID:     "build123",
 		token:       "faketoken",
@@ -186,7 +188,8 @@ func parseLogData(input io.Reader) (logMap, error) {
 func TestParseFlags(t *testing.T) {
 	os.Setenv("SD_TOKEN", mockToken)
 	os.Setenv("SD_BUILDID", mockBuildID)
-	os.Setenv("SD_API_URI", mockURL)
+	os.Setenv("SD_STORE_URL", mockStoreURL)
+	os.Setenv("SD_API_URL", mockAPIURL)
 	a := parseFlags()
 	if a.token != mockToken {
 		t.Errorf("App token = %s, want %s", a.token, mockToken)
@@ -200,8 +203,12 @@ func TestParseFlags(t *testing.T) {
 		t.Errorf("Build ID = %s, want %s", a.buildID, mockBuildID)
 	}
 
-	if a.url != mockURL {
-		t.Errorf("URL = %s, want %s", a.url, mockURL)
+	if a.storeUrl != mockStoreURL {
+		t.Errorf("URL = %s, want %s", a.storeUrl, mockStoreURL)
+	}
+
+	if a.apiUrl != mockAPIURL {
+		t.Errorf("URL = %s, want %s", a.apiUrl, mockAPIURL)
 	}
 
 	if a.linesPerFile != mockLinesPerFile {


### PR DESCRIPTION
- add additional flag for screwdriver API url so that we can update build step meta later on.

**Note**: this is a BREAKING CHANGE. Will bump launcher version when we pull this log-service in.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1114