### PR TITLE
fix: increase request timeout to 30 secs

### DIFF
--- a/sdstoreuploader/sdstoreuploader.go
+++ b/sdstoreuploader/sdstoreuploader.go
@@ -34,7 +34,7 @@ func NewFileUploader(buildID, url, token string) SDStoreUploader {
 		buildID,
 		url,
 		token,
-		&http.Client{Timeout: 10 * time.Second},
+		&http.Client{Timeout: 60 * time.Second},
 	}
 }
 

--- a/sdstoreuploader/sdstoreuploader.go
+++ b/sdstoreuploader/sdstoreuploader.go
@@ -34,7 +34,7 @@ func NewFileUploader(buildID, url, token string) SDStoreUploader {
 		buildID,
 		url,
 		token,
-		&http.Client{Timeout: 60 * time.Second},
+		&http.Client{Timeout: 30 * time.Second},
 	}
 }
 


### PR DESCRIPTION
This is posting logs to store. We're seeing 499 from the store side because it's taking more than 10 seconds to upload thus log-service just close the connection and retry. Increase it to 30 seconds to align with the default s3 timeout of 2 minutes.