### PR TITLE
fix: correct the url order with sub path

### DIFF
--- a/sdstoreuploader/sdstoreuploader.go
+++ b/sdstoreuploader/sdstoreuploader.go
@@ -78,7 +78,7 @@ func (s *sdUploader) makeURL(storePath string) (*url.URL, error) {
 		return nil, fmt.Errorf("bad url %s: %v", s.url, err)
 	}
 	version := "v1"
-	u.Path = path.Join(version, u.Path, "builds", s.buildID, storePath)
+	u.Path = path.Join(u.Path, version, "builds", s.buildID, storePath)
 
 	return u, nil
 }


### PR DESCRIPTION
fix the order of the Url path, it should be `/subpath/v1/builds/` instead of `/v1/subpath/builds`