### PR TITLE
fix: pin golang image version

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,6 +1,6 @@
 
 shared:
-    image: golang
+    image: golang:1.10
     environment:
         GOPATH: /sd/workspace
 


### PR DESCRIPTION
latest golang image doesn't work with goreleaser
we did the same thing for launcher: https://github.com/screwdriver-cd/launcher/pull/214