### PR TITLE
fix: create temp log files under /sd

### DIFF
--- a/logfilesaver.go
+++ b/logfilesaver.go
@@ -29,7 +29,7 @@ type logFile struct {
 
 // newLogFile returns a logFile object for saving a single file to the Store.
 func newLogFile(uploader sdstoreuploader.SDStoreUploader, storePath string) (*logFile, error) {
-	file, err := ioutil.TempFile("", filepath.Base(storePath))
+	file, err := ioutil.TempFile("/sd", filepath.Base(storePath))
 	if err != nil {
 		return &logFile{}, fmt.Errorf("creating temporary file for %s: %v", storePath, err)
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Generating temporary files under /tmp directory sometimes messes with user processes which might mess with the /tmp folder

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
