### PR TITLE
fix: set upload timeout to 10s

### DIFF
--- a/sdstoreuploader/sdstoreuploader.go
+++ b/sdstoreuploader/sdstoreuploader.go
@@ -34,7 +34,7 @@ func NewFileUploader(buildID, url, token string) SDStoreUploader {
 		buildID,
 		url,
 		token,
-		&http.Client{Timeout: 30 * time.Second},
+		&http.Client{Timeout: 10 * time.Second},
 	}
 }
 


### PR DESCRIPTION
Previously our store service is not stable and takes quite a long time to process. Since it's stable now, reset the timeout to a reasonable number.