### PR TITLE
fix(1938): alibity to customize temporary log file folder

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,11 +7,9 @@ builds:
       - amd64
     # Include the default settings from https://goreleaser.com/#builds
     # Also include static compilation
-    ldflags: -d -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
     # Ensure the binary is static
     env:
       - CGO_ENABLED=0
-
-archive:
-  format: binary
-  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/screwdriver-cd/log-service
+
+go 1.13

--- a/logfilesaver.go
+++ b/logfilesaver.go
@@ -29,8 +29,8 @@ type logFile struct {
 }
 
 // newLogFile returns a logFile object for saving a single file to the Store.
-func newLogFile(uploader sduploader.SDUploader, storePath string) (*logFile, error) {
-	file, err := ioutil.TempFile("/sd", filepath.Base(storePath))
+func newLogFile(uploader sduploader.SDUploader, logFolder string, storePath string) (*logFile, error) {
+	file, err := ioutil.TempFile(logFolder, filepath.Base(storePath))
 	if err != nil {
 		return &logFile{}, fmt.Errorf("creating temporary file for %s: %v", storePath, err)
 	}

--- a/logservice.go
+++ b/logservice.go
@@ -125,8 +125,8 @@ type app struct {
 	apiUrl,
 	storeUrl,
 	buildLogFile string
-	linesPerFile int
-	isLocal      bool
+	linesPerFile   int
+	isLocal        bool
 	buildLogFolder string
 }
 

--- a/logservice.go
+++ b/logservice.go
@@ -44,6 +44,7 @@ func parseFlags() app {
 	flag.IntVar(&a.linesPerFile, "lines-per-file", defaultLinesPerFile, "Max number of lines per file when uploading ($SD_LINESPERFILE)")
 	flag.BoolVar(&a.isLocal, "local-mode", false, "Build run in local mode")
 	flag.StringVar(&a.buildLogFile, "build-log-file", "", "Path to the build log file in local mode")
+	flag.StringVar(&a.buildLogFolder, "build-log-folder", "/sd", "Directory where build log files are stored")
 	flag.Parse()
 
 	if len(os.Getenv("SD_LINESPERFILE")) != 0 {
@@ -178,7 +179,7 @@ func (a app) LogReader() io.Reader {
 
 // StepSaver returns a new StepSaver object based on the app config
 func (a app) StepSaver(step string) StepSaver {
-	return NewStepSaver(step, a.Uploader(), a.linesPerFile, a.ScrewdriverAPI())
+	return NewStepSaver(step, a.Uploader(), a.linesPerFile, a.ScrewdriverAPI(), a.buildLogFolder)
 }
 
 // BuildID returns the id of the build being processed.

--- a/logservice.go
+++ b/logservice.go
@@ -25,6 +25,7 @@ const (
 	startupTimeout      = 10 * time.Minute
 	logBufferSize       = 200
 	maxLineSize         = 5000
+	defaultLogFolder    = "/sd"
 )
 
 func main() {
@@ -44,7 +45,7 @@ func parseFlags() app {
 	flag.IntVar(&a.linesPerFile, "lines-per-file", defaultLinesPerFile, "Max number of lines per file when uploading ($SD_LINESPERFILE)")
 	flag.BoolVar(&a.isLocal, "local-mode", false, "Build run in local mode")
 	flag.StringVar(&a.buildLogFile, "build-log-file", "", "Path to the build log file in local mode")
-	flag.StringVar(&a.buildLogFolder, "build-log-folder", "/sd", "Directory where build log files are stored")
+	flag.StringVar(&a.buildLogFolder, "build-log-folder", defaultLogFolder, "Directory where build log files are stored")
 	flag.Parse()
 
 	if len(os.Getenv("SD_LINESPERFILE")) != 0 {
@@ -126,6 +127,7 @@ type app struct {
 	buildLogFile string
 	linesPerFile int
 	isLocal      bool
+	buildLogFolder string
 }
 
 // Uploader returns an Uploader object for the Screwdriver Store

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,18 +1,21 @@
 
 shared:
-    image: golang:1.10
+    image: golang:1.12
     environment:
         GOPATH: /sd/workspace
+        GO111MODULE: on
 
 jobs:
     main:
         requires: [~pr, ~commit]
         steps:
-            - get: go get -t ./...
+            - gover: go version
+            - install: go mod download
             - vet: go vet ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - test: go test -race ./...
+            - gofmt: (! gofmt -d . | grep '^')
+            - test: go test ./... -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out -coverpkg=./...
             - build: go build -a -o $SD_ARTIFACTS_DIR/logservice
+            - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
 
     publish:
         requires: [main]

--- a/stepsaver.go
+++ b/stepsaver.go
@@ -34,7 +34,6 @@ type StepSaver interface {
 
 type stepSaver struct {
 	StepName       string
-	logFolder      string
 	Uploader       sduploader.SDUploader
 	ScrewdriverAPI screwdriver.API
 	lineCount      int
@@ -44,6 +43,7 @@ type stepSaver struct {
 	ticker         *time.Ticker
 	mutex          sync.Mutex
 	linesPerFile   int
+	logFolder      string
 }
 
 // Close cancels the save ticker, saves the logs for this step, and closes the logFiles.
@@ -172,7 +172,7 @@ func (s *stepSaver) Save() error {
 
 // NewStepSaver creates a StepSaver out of a name and sduploader.SDUploader
 func NewStepSaver(name string, uploader sduploader.SDUploader, linesPerFile int, screwdriverAPI screwdriver.API, logFolder string) StepSaver {
-  s := &stepSaver{StepName: name, Uploader: uploader, ticker: time.NewTicker(uploadInterval), linesPerFile: linesPerFile, ScrewdriverAPI: screwdriverAPI, logFolder: logFolder}
+	s := &stepSaver{StepName: name, Uploader: uploader, ticker: time.NewTicker(uploadInterval), linesPerFile: linesPerFile, ScrewdriverAPI: screwdriverAPI, logFolder: logFolder}
 	e := json.NewEncoder(s)
 	s.encoder = e
 

--- a/stepsaver.go
+++ b/stepsaver.go
@@ -34,6 +34,7 @@ type StepSaver interface {
 
 type stepSaver struct {
 	StepName       string
+	logFolder      string
 	Uploader       sduploader.SDUploader
 	ScrewdriverAPI screwdriver.API
 	lineCount      int
@@ -95,8 +96,8 @@ func (s *stepSaver) WriteLog(l *logLine) error {
 }
 
 // newLogFile is a helper for adding a logFile to the internal collection of logFiles.
-func (s *stepSaver) newLogFile(storePath string) error {
-	lf, err := newLogFile(s.Uploader, storePath)
+func (s *stepSaver) newLogFile(fileName string) error {
+	lf, err := newLogFile(s.Uploader, s.logFolder, fileName)
 	if err != nil {
 		return err
 	}
@@ -170,8 +171,8 @@ func (s *stepSaver) Save() error {
 }
 
 // NewStepSaver creates a StepSaver out of a name and sduploader.SDUploader
-func NewStepSaver(name string, uploader sduploader.SDUploader, linesPerFile int, screwdriverAPI screwdriver.API) StepSaver {
-	s := &stepSaver{StepName: name, Uploader: uploader, ticker: time.NewTicker(uploadInterval), linesPerFile: linesPerFile, ScrewdriverAPI: screwdriverAPI}
+func NewStepSaver(name string, uploader sduploader.SDUploader, linesPerFile int, screwdriverAPI screwdriver.API, logFolder string) StepSaver {
+  s := &stepSaver{StepName: name, Uploader: uploader, ticker: time.NewTicker(uploadInterval), linesPerFile: linesPerFile, ScrewdriverAPI: screwdriverAPI, logFolder: logFolder}
 	e := json.NewEncoder(s)
 	s.encoder = e
 

--- a/stepsaver_test.go
+++ b/stepsaver_test.go
@@ -42,7 +42,7 @@ func (m MockAPI) UpdateStepLines(stepName string, lineCount int) error {
 }
 
 func newTestStepSaver() *stepSaver {
-	s := &stepSaver{StepName: testStepName, Uploader: &mockSDUploader{}, ScrewdriverAPI: &MockAPI{}, linesPerFile: defaultLinesPerFile}
+	s := &stepSaver{StepName: testStepName, Uploader: &mockSDUploader{}, ScrewdriverAPI: &MockAPI{}, linesPerFile: defaultLinesPerFile, logFolder: "/tmp"}
 	e := json.NewEncoder(s)
 	s.encoder = e
 
@@ -162,7 +162,7 @@ func TestSaverUploadOnNewFile(t *testing.T) {
 	}
 	screwdriverAPI := mockAPI(t, testStepName)
 
-	s := NewStepSaver(testStepName, uploader, defaultLinesPerFile, screwdriverAPI)
+	s := NewStepSaver(testStepName, uploader, defaultLinesPerFile, screwdriverAPI, "/tmp")
 	for i := 0; i < defaultLinesPerFile; i++ {
 		l := &logLine{3456, fmt.Sprintf("LogMsg #%d", i), "step1"}
 		s.WriteLog(l)
@@ -206,7 +206,7 @@ func TestSaverUploadOnTimeElapsed(t *testing.T) {
 	screwdriverAPI := mockAPI(t, testStepName)
 
 	gotUploads := []upload{}
-	s := NewStepSaver(testStepName, uploader, defaultLinesPerFile, screwdriverAPI)
+	s := NewStepSaver(testStepName, uploader, defaultLinesPerFile, screwdriverAPI, "/tmp")
 	for i := 0; i < defaultLinesPerFile; i++ {
 		l := &logLine{3456, fmt.Sprintf("LogMsg #%d", i), "step1"}
 		s.WriteLog(l)
@@ -247,7 +247,7 @@ func TestSaverUploadOnClose(t *testing.T) {
 	}
 	screwdriverAPI := mockAPI(t, testStepName)
 
-	s := NewStepSaver(testStepName, uploader, defaultLinesPerFile, screwdriverAPI)
+	s := NewStepSaver(testStepName, uploader, defaultLinesPerFile, screwdriverAPI, "/tmp")
 	l := &logLine{4567, fmt.Sprintf("LogMsg #1"), "step1"}
 	s.WriteLog(l)
 


### PR DESCRIPTION
## Context

log-service has hardcoded path "/sd" for temporary log file 

## Objective

Expose a cli option to pass in log file path.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1938

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
