### PR TITLE
fix: use format binary for go releaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,4 +12,5 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  - format: binary
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
## Context

goreleaser willl gzip binary without `binary` format

## Objective

make goreleaser to compatible with previous releases.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
