### PR TITLE
fix: double timeout against SD API so that it's consistent with launcher

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -47,7 +47,7 @@ func New(buildID, url, token string) (API, error) {
 		buildID,
 		url,
 		token,
-		&http.Client{Timeout: 10 * time.Second},
+		&http.Client{Timeout: 20 * time.Second},
 	}
 	return API(newAPI), nil
 }


### PR DESCRIPTION
## Context

We are seeing frequent timeouts against Store API 

## Objective

Double timeout against store API so that it's consistent with launcher timeout against SD API https://github.com/screwdriver-cd/launcher/blob/master/screwdriver/screwdriver.go#L74

## References

https://github.com/screwdriver-cd/launcher/blob/master/screwdriver/screwdriver.go#L74

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
