### PR TITLE
fix: duplicate logs

### DIFF
--- a/sduploader/sdlocaluploader.go
+++ b/sduploader/sdlocaluploader.go
@@ -1,6 +1,8 @@
 package sduploader
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"os"
 )
@@ -13,6 +15,25 @@ func NewLocalUploader(logFile string) SDUploader {
 	return &sdLocalUploader{
 		logFile: logFile,
 	}
+}
+
+func getLastLine(filePath string) (string, error) {
+	lastLine := ""
+	p, err := os.Open(filePath)
+	if err != nil {
+		return lastLine, err
+	}
+	defer p.Close()
+
+	scanner := bufio.NewScanner(p)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) > 0 {
+			lastLine = line
+		}
+	}
+
+	return lastLine, nil
 }
 
 func (s *sdLocalUploader) Upload(path string, filePath string) error {
@@ -28,9 +49,33 @@ func (s *sdLocalUploader) Upload(path string, filePath string) error {
 	}
 	defer output.Close()
 
-	_, err = io.Copy(output, input)
+	// Skip lines that have already been logged
+	lastLine, err := getLastLine(s.logFile)
 	if err != nil {
 		return err
+	}
+	inputScanner := bufio.NewScanner(input)
+	matched := false
+	if len(lastLine) > 0 {
+		for inputScanner.Scan() {
+			if matched {
+				_, err = output.Write(([]byte)(fmt.Sprintf("%s\n", inputScanner.Text())))
+				if err != nil {
+					return err
+				}
+			} else if lastLine == inputScanner.Text() {
+				matched = true
+			}
+		}
+	}
+
+	// Output all if there are no lines already logged
+	if !matched {
+		input.Seek(0, 0)
+		_, err = io.Copy(output, input)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/sduploader/sdlocaluploader_test.go
+++ b/sduploader/sdlocaluploader_test.go
@@ -60,3 +60,55 @@ func TestWriteLog(t *testing.T) {
 	}
 
 }
+
+func TestOverwriteLog(t *testing.T) {
+	testLogFile, err := ioutil.TempFile("", "build.log")
+	if err != nil {
+		panic(err)
+	}
+
+	logFileName := testLogFile.Name()
+	uploader := &sdLocalUploader{
+		logFile: logFileName,
+	}
+	defer os.Remove(logFileName)
+
+	testPath := "dummy"
+	logFileExpected := testFile().Name()
+
+	uploader.Upload(testPath, logFileExpected)
+
+	expectedLastLine := "{\"t\":158380,\"m\":\"msg 20\",\"s\":\"step4\"}"
+	actualLastLine, err := getLastLine(logFileExpected)
+	if err != nil {
+		t.Fatalf("Couldn't get lastLine of log file: %v", err)
+	}
+	if expectedLastLine != actualLastLine {
+		t.Errorf(
+			"There are something wrong with written logs\nexpected: %s \nactual: %s",
+			expectedLastLine,
+			actualLastLine,
+		)
+	}
+
+	uploader.Upload(testPath, logFileExpected)
+
+	expected, err := ioutil.ReadFile(logFileExpected)
+	if err != nil {
+		panic(err)
+	}
+
+	actual, err := ioutil.ReadFile(logFileName)
+	if err != nil {
+		t.Fatalf("Couldn't read log file: %v", err)
+	}
+
+	if !bytes.Equal(expected, actual) {
+		t.Errorf(
+			"There are something wrong with written logs\nexpected: %s \nactual: %s",
+			expected,
+			actual,
+		)
+	}
+
+}


### PR DESCRIPTION
## Context
In time-consuming builds, log uploads are done many times on a regular basis. Therefore, if we add to the fixed log file called `builds.log` like sd-local, the same part will be added to the log file many times every upload.

## Objective
When executing gradle build with sd-local, some logs were duplicated.

`builds.log`:
```
(snip)
{"t":1588837397132,"m":"$ gradle clean build test","n":0,"s":"test"}
{"t":1588837397132,"m":"","n":1,"s":"test"}
{"t":1588837397281,"m":"Downloading https://services.gradle.org/distributions/gradle-4.1-bin.zip","n":2,"s":"test"}
{"t":1588837397132,"m":"$ gradle clean build test","n":0,"s":"test"}
{"t":1588837397132,"m":"","n":1,"s":"test"}
{"t":1588837397281,"m":"Downloading https://services.gradle.org/distributions/gradle-4.1-bin.zip","n":2,"s":"test"}
{"t":1588837399228,"m":"................................................................","n":3,"s":"test"}
(snip)
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
