### PR TITLE
fix(2106): fix log service api retry n timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # goreleaser
 
 /dist/
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/screwdriver-cd/log-service
 
-go 1.13
+go 1.14
+
+require (
+	github.com/hashicorp/go-retryablehttp v0.6.6
+	github.com/stretchr/testify v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
+github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,6 +1,6 @@
 
 shared:
-    image: golang:1.12
+    image: golang:1.14
     environment:
         GOPATH: /sd/workspace
         GO111MODULE: on

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -3,6 +3,8 @@ package screwdriver
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,37 +14,22 @@ import (
 	"time"
 )
 
-func makeFakeHTTPClient(t *testing.T, code int, body string) *http.Client {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wantToken := "faketoken"
-		wantTokenHeader := fmt.Sprintf("Bearer %s", wantToken)
-
-		validateHeader(t, "Authorization", wantTokenHeader)
-		w.WriteHeader(code)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, body)
-	}))
-
-	transport := &http.Transport{
-		Proxy: func(req *http.Request) (*url.URL, error) {
-			return url.Parse(server.URL)
-		},
-	}
-
-	return &http.Client{Transport: transport}
-}
-
 func makeValidatedFakeHTTPClient(t *testing.T, code int, body string, v func(r *http.Request)) *http.Client {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wantToken := "faketoken"
 		wantTokenHeader := fmt.Sprintf("Bearer %s", wantToken)
 
+		fmt.Println("in api")
 		validateHeader(t, "Authorization", wantTokenHeader)
 		v(r)
 
 		w.WriteHeader(code)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, body)
+		if code == 500 {
+			time.Sleep(time.Duration(2) * time.Second)
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}
 	}))
 
 	transport := &http.Transport{
@@ -67,12 +54,9 @@ func validateHeader(t *testing.T, key, value string) func(r *http.Request) {
 	}
 }
 
-func TestMain(m *testing.M) {
-	sleep = func(d time.Duration) {}
-	os.Exit(m.Run())
-}
-
 func TestUpdateStepLines(t *testing.T) {
+	var client *retryablehttp.Client
+	client = retryablehttp.NewClient()
 	http := makeValidatedFakeHTTPClient(t, 200, "{}", func(r *http.Request) {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(r.Body)
@@ -82,11 +66,53 @@ func TestUpdateStepLines(t *testing.T) {
 			t.Errorf("buf.String() = %q", buf.String())
 		}
 	})
-	testAPI := api{"123", "http://fakeurl", "faketoken", http}
+	client.HTTPClient = http
+	testAPI := api{"123", "http://fakeurl", "faketoken", client}
 
 	err := testAPI.UpdateStepLines("step1", 2000)
 
 	if err != nil {
 		t.Errorf("Unexpected error from UpdateStepStart: %v", err)
 	}
+}
+
+func TestUpdateStepLinesRetry(t *testing.T) {
+	var client *retryablehttp.Client
+	client = retryablehttp.NewClient()
+	http := makeValidatedFakeHTTPClient(t, 500, "{}", func(r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+
+		want := regexp.MustCompile(`{"lines":2000}`)
+		if !want.MatchString(buf.String()) {
+			t.Errorf("buf.String() = %q", buf.String())
+		}
+	})
+	client.HTTPClient = http
+	maxRetries = 2
+	httpTimeout = time.Duration(1) * time.Second
+
+	testAPI := api{"123", "http://fakeurl", "faketoken", client}
+
+	err := testAPI.UpdateStepLines("step1", 2000)
+	assert.Contains(t, err.Error(), "giving up after 3 attempts")
+}
+
+func TestNewDefaults(t *testing.T) {
+	maxRetries = 5
+	httpTimeout = time.Duration(20) * time.Second
+
+	os.Setenv("LOGSERVICE_SDAPI_TIMEOUT_SECS", "")
+	os.Setenv("LOGSERVICE_SDAPI_MAXRETRIES", "")
+	_, _ = New("1", "http://fakeurl", "fake")
+	assert.Equal(t, httpTimeout, time.Duration(20)*time.Second)
+	assert.Equal(t, maxRetries, 5)
+}
+
+func TestNew(t *testing.T) {
+	os.Setenv("LOGSERVICE_SDAPI_TIMEOUT_SECS", "10")
+	os.Setenv("LOGSERVICE_SDAPI_MAXRETRIES", "1")
+	_, _ = New("1", "http://fakeurl", "fake")
+	assert.Equal(t, httpTimeout, time.Duration(10)*time.Second)
+	assert.Equal(t, maxRetries, 1)
 }

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -91,6 +91,8 @@ func TestUpdateStepLinesRetry(t *testing.T) {
 	client.HTTPClient = http
 	maxRetries = 2
 	httpTimeout = time.Duration(1) * time.Second
+	client.RetryMax = maxRetries
+	client.HTTPClient.Timeout = httpTimeout
 
 	testAPI := api{"123", "http://fakeurl", "faketoken", client}
 

--- a/sduploader/sdstoreuploader_test.go
+++ b/sduploader/sdstoreuploader_test.go
@@ -3,6 +3,8 @@ package sduploader
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -58,6 +60,8 @@ func testFile() *os.File {
 }
 
 func TestFileUpload(t *testing.T) {
+	var retryHttpClient *retryablehttp.Client
+	retryHttpClient = retryablehttp.NewClient()
 	testBuildID := "testbuild"
 	url := "http://fakeurl"
 	token := "faketoken"
@@ -66,7 +70,7 @@ func TestFileUpload(t *testing.T) {
 		testBuildID,
 		url,
 		token,
-		&http.Client{Timeout: 10 * time.Second},
+		retryHttpClient,
 	}
 	called := false
 
@@ -104,7 +108,7 @@ func TestFileUpload(t *testing.T) {
 			t.Errorf("Wrong Content-Length sent to uploader. Got %d, want %d", r.ContentLength, fsize)
 		}
 	})
-	uploader.client = http
+	uploader.client.HTTPClient = http
 	uploader.Upload(testPath, testFile().Name())
 
 	if !called {
@@ -113,7 +117,8 @@ func TestFileUpload(t *testing.T) {
 }
 
 func TestFileUploadRetry(t *testing.T) {
-	retryScaler = .01
+	var retryHttpClient *retryablehttp.Client
+	retryHttpClient = retryablehttp.NewClient()
 	testBuildID := "testbuild"
 	url := "http://fakeurl"
 	token := "faketoken"
@@ -122,19 +127,38 @@ func TestFileUploadRetry(t *testing.T) {
 		testBuildID,
 		url,
 		token,
-		&http.Client{Timeout: 10 * time.Second},
+		retryHttpClient,
 	}
 
+	maxRetries = 2
 	callCount := 0
 	http := makeFakeHTTPClient(t, 500, "ERROR", func(r *http.Request) {
 		callCount++
 	})
-	uploader.client = http
+	uploader.client.HTTPClient = http
 	err := uploader.Upload(testPath, testFile().Name())
 	if err == nil {
 		t.Error("Expected error from uploader.Upload(), got nil")
 	}
-	if callCount != 6 {
+	if callCount != 3 {
 		t.Errorf("Expected 6 retries, got %d", callCount)
 	}
+}
+
+func TestNewStoreUploaderDefaults(t *testing.T) {
+	maxRetries = 5
+	httpTimeout = time.Duration(20) * time.Second
+	os.Setenv("LOGSERVICE_STOREAPI_TIMEOUT_SECS", "")
+	os.Setenv("LOGSERVICE_STOREAPI_MAXRETRIES", "")
+	_ = NewStoreUploader("1", "http://fakeurl", "fake")
+	assert.Equal(t, httpTimeout, time.Duration(20)*time.Second)
+	assert.Equal(t, maxRetries, 5)
+}
+
+func TestNewStoreUploader(t *testing.T) {
+	os.Setenv("LOGSERVICE_STOREAPI_TIMEOUT_SECS", "10")
+	os.Setenv("LOGSERVICE_STOREAPI_MAXRETRIES", "1")
+	_ = NewStoreUploader("1", "http://fakeurl", "fake")
+	assert.Equal(t, httpTimeout, time.Duration(10)*time.Second)
+	assert.Equal(t, maxRetries, 1)
 }

--- a/sduploader/sdstoreuploader_test.go
+++ b/sduploader/sdstoreuploader_test.go
@@ -119,6 +119,8 @@ func TestFileUpload(t *testing.T) {
 func TestFileUploadRetry(t *testing.T) {
 	var retryHttpClient *retryablehttp.Client
 	retryHttpClient = retryablehttp.NewClient()
+	retryHttpClient.RetryMax = 2
+	retryHttpClient.HTTPClient.Timeout = time.Duration(1) * time.Second
 	testBuildID := "testbuild"
 	url := "http://fakeurl"
 	token := "faketoken"
@@ -129,8 +131,6 @@ func TestFileUploadRetry(t *testing.T) {
 		token,
 		retryHttpClient,
 	}
-
-	maxRetries = 2
 	callCount := 0
 	http := makeFakeHTTPClient(t, 500, "ERROR", func(r *http.Request) {
 		callCount++
@@ -141,7 +141,7 @@ func TestFileUploadRetry(t *testing.T) {
 		t.Error("Expected error from uploader.Upload(), got nil")
 	}
 	if callCount != 3 {
-		t.Errorf("Expected 6 retries, got %d", callCount)
+		t.Errorf("Expected 3 retries, got %d", callCount)
 	}
 }
 


### PR DESCRIPTION
## Context

Frequent timeouts from log service to API and Store.

## Objective

Switch default http client to retryablehttp client and add timeout, retry configurations.

## References

[Timeouts from log service to SD API & Store](https://github.com/screwdriver-cd/screwdriver/issues/2106)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
