### PR TITLE
fix: Unify environment variables for retry

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -50,13 +50,13 @@ type api struct {
 // New returns a new API object
 func New(buildID, url, token string) (API, error) {
 	// read config from env variables
-	if strings.TrimSpace(os.Getenv("LOGSERVICE_SDAPI_TIMEOUT_SECS")) != "" {
-		apiTimeout, _ := strconv.Atoi(os.Getenv("LOGSERVICE_SDAPI_TIMEOUT_SECS"))
+	if strings.TrimSpace(os.Getenv("SDAPI_TIMEOUT_SECS")) != "" {
+		apiTimeout, _ := strconv.Atoi(os.Getenv("SDAPI_TIMEOUT_SECS"))
 		httpTimeout = time.Duration(apiTimeout) * time.Second
 	}
 
-	if strings.TrimSpace(os.Getenv("LOGSERVICE_SDAPI_MAXRETRIES")) != "" {
-		maxRetries, _ = strconv.Atoi(os.Getenv("LOGSERVICE_SDAPI_MAXRETRIES"))
+	if strings.TrimSpace(os.Getenv("SDAPI_MAXRETRIES")) != "" {
+		maxRetries, _ = strconv.Atoi(os.Getenv("SDAPI_MAXRETRIES"))
 	}
 
 	retryClient := retryablehttp.NewClient()

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -3,8 +3,6 @@ package screwdriver
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,6 +10,9 @@ import (
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
 )
 
 func makeValidatedFakeHTTPClient(t *testing.T, code int, body string, v func(r *http.Request)) *http.Client {
@@ -104,16 +105,16 @@ func TestNewDefaults(t *testing.T) {
 	maxRetries = 5
 	httpTimeout = time.Duration(20) * time.Second
 
-	os.Setenv("LOGSERVICE_SDAPI_TIMEOUT_SECS", "")
-	os.Setenv("LOGSERVICE_SDAPI_MAXRETRIES", "")
+	os.Setenv("SDAPI_TIMEOUT_SECS", "")
+	os.Setenv("SDAPI_MAXRETRIES", "")
 	_, _ = New("1", "http://fakeurl", "fake")
 	assert.Equal(t, httpTimeout, time.Duration(20)*time.Second)
 	assert.Equal(t, maxRetries, 5)
 }
 
 func TestNew(t *testing.T) {
-	os.Setenv("LOGSERVICE_SDAPI_TIMEOUT_SECS", "10")
-	os.Setenv("LOGSERVICE_SDAPI_MAXRETRIES", "1")
+	os.Setenv("SDAPI_TIMEOUT_SECS", "10")
+	os.Setenv("SDAPI_MAXRETRIES", "1")
 	_, _ = New("1", "http://fakeurl", "fake")
 	assert.Equal(t, httpTimeout, time.Duration(10)*time.Second)
 	assert.Equal(t, maxRetries, 1)

--- a/sduploader/sdstoreuploader.go
+++ b/sduploader/sdstoreuploader.go
@@ -2,7 +2,6 @@ package sduploader
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	"io"
 	"io/ioutil"
 	"log"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 // default configs
@@ -37,13 +38,13 @@ type sdStoreUploader struct {
 // NewStoreUploader returns an SDUploader for a given build.
 func NewStoreUploader(buildID, url, token string) SDUploader {
 	// read config from env variables
-	if strings.TrimSpace(os.Getenv("LOGSERVICE_STOREAPI_TIMEOUT_SECS")) != "" {
-		storeTimeout, _ := strconv.Atoi(os.Getenv("LOGSERVICE_STOREAPI_TIMEOUT_SECS"))
+	if strings.TrimSpace(os.Getenv("STOREAPI_TIMEOUT_SECS")) != "" {
+		storeTimeout, _ := strconv.Atoi(os.Getenv("STOREAPI_TIMEOUT_SECS"))
 		httpTimeout = time.Duration(storeTimeout) * time.Second
 	}
 
-	if strings.TrimSpace(os.Getenv("LOGSERVICE_STOREAPI_MAXRETRIES")) != "" {
-		maxRetries, _ = strconv.Atoi(os.Getenv("LOGSERVICE_STOREAPI_MAXRETRIES"))
+	if strings.TrimSpace(os.Getenv("STOREAPI_MAXRETRIES")) != "" {
+		maxRetries, _ = strconv.Atoi(os.Getenv("STOREAPI_MAXRETRIES"))
 	}
 
 	retryClient := retryablehttp.NewClient()

--- a/sduploader/sdstoreuploader_test.go
+++ b/sduploader/sdstoreuploader_test.go
@@ -3,8 +3,6 @@ package sduploader
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +10,9 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
 )
 
 func validateHeader(t *testing.T, key, value string) func(r *http.Request) {
@@ -148,16 +149,16 @@ func TestFileUploadRetry(t *testing.T) {
 func TestNewStoreUploaderDefaults(t *testing.T) {
 	maxRetries = 5
 	httpTimeout = time.Duration(20) * time.Second
-	os.Setenv("LOGSERVICE_STOREAPI_TIMEOUT_SECS", "")
-	os.Setenv("LOGSERVICE_STOREAPI_MAXRETRIES", "")
+	os.Setenv("STOREAPI_TIMEOUT_SECS", "")
+	os.Setenv("STOREAPI_MAXRETRIES", "")
 	_ = NewStoreUploader("1", "http://fakeurl", "fake")
 	assert.Equal(t, httpTimeout, time.Duration(20)*time.Second)
 	assert.Equal(t, maxRetries, 5)
 }
 
 func TestNewStoreUploader(t *testing.T) {
-	os.Setenv("LOGSERVICE_STOREAPI_TIMEOUT_SECS", "10")
-	os.Setenv("LOGSERVICE_STOREAPI_MAXRETRIES", "1")
+	os.Setenv("STOREAPI_TIMEOUT_SECS", "10")
+	os.Setenv("STOREAPI_MAXRETRIES", "1")
 	_ = NewStoreUploader("1", "http://fakeurl", "fake")
 	assert.Equal(t, httpTimeout, time.Duration(10)*time.Second)
 	assert.Equal(t, maxRetries, 1)


### PR DESCRIPTION
## Context
The environment variables for retry exist separately in launcher and log-service, so we unify them.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- rename `LOGSERVICE_SDAPI_TIMEOUT_SEC` to `SDAPI_TIMEOUT_SECS`
- rename `LOGSERVICE_SDAPI_MAXRETRIES` to `SDAPI_MAXRETRIES`
- rename `LOGSERVICE_STOREAPI_TIMEOUT_SECS` to `STOREAPI_TIMEOUT_SECS`
- rename `LOGSERVICE_STOREAPI_MAXRETRIES` to `STOREAPI_MAXRETRIES`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/launcher/pull/357#discussion_r444359365
https://github.com/screwdriver-cd/launcher/pull/358
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
